### PR TITLE
Add participants and YAML config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# timebank
-Banco del tiempo
+# Timebank
+
+Microservicio para gestionar un banco del tiempo. Construido con Spring Boot, arquitectura hexagonal, Lombok y MapStruct.
+
+## Compilación
+
+Este proyecto utiliza Maven. Para compilar y ejecutar las pruebas:
+
+```bash
+mvn clean test
+```
+
+## Ejecución
+
+```bash
+mvn spring-boot:run
+```
+
+La API REST estará disponible en `http://localhost:8080`.
+
+La configuración de Spring se encuentra en `src/main/resources/application.yml`.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,66 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>timebank</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.1.2</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mapstruct.version>1.5.5.Final</mapstruct.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/timebank/TimebankApplication.java
+++ b/src/main/java/com/example/timebank/TimebankApplication.java
@@ -1,0 +1,11 @@
+package com.example.timebank;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TimebankApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(TimebankApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/timebank/adapter/rest/ActivityController.java
+++ b/src/main/java/com/example/timebank/adapter/rest/ActivityController.java
@@ -1,0 +1,26 @@
+package com.example.timebank.adapter.rest;
+
+import com.example.timebank.dto.ActivityDto;
+import com.example.timebank.service.ActivityService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/activities")
+@RequiredArgsConstructor
+public class ActivityController {
+    private final ActivityService activityService;
+
+    @PostMapping
+    public ResponseEntity<ActivityDto> create(@RequestBody ActivityDto dto) {
+        return ResponseEntity.ok(activityService.create(dto));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ActivityDto>> findAll() {
+        return ResponseEntity.ok(activityService.findAll());
+    }
+}

--- a/src/main/java/com/example/timebank/adapter/rest/UserController.java
+++ b/src/main/java/com/example/timebank/adapter/rest/UserController.java
@@ -1,0 +1,26 @@
+package com.example.timebank.adapter.rest;
+
+import com.example.timebank.dto.UserDto;
+import com.example.timebank.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<UserDto> create(@RequestBody UserDto dto) {
+        return ResponseEntity.ok(userService.create(dto));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<UserDto>> findAll() {
+        return ResponseEntity.ok(userService.findAll());
+    }
+}

--- a/src/main/java/com/example/timebank/domain/Activity.java
+++ b/src/main/java/com/example/timebank/domain/Activity.java
@@ -1,0 +1,30 @@
+package com.example.timebank.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.ManyToMany;
+import java.util.Set;
+import lombok.Data;
+
+@Entity
+@Data
+public class Activity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String description;
+
+    private int durationHours;
+
+    @ManyToOne
+    private User instructor;
+
+    @ManyToMany
+    private Set<User> participants;
+}

--- a/src/main/java/com/example/timebank/domain/User.java
+++ b/src/main/java/com/example/timebank/domain/User.java
@@ -1,0 +1,29 @@
+package com.example.timebank.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Data;
+
+import java.util.Objects;
+
+@Entity
+@Data
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String firstName;
+
+    private String lastName;
+
+    private String email;
+
+    private String phone;
+
+    private String password;
+
+    private double hoursCredit;
+}

--- a/src/main/java/com/example/timebank/dto/ActivityDto.java
+++ b/src/main/java/com/example/timebank/dto/ActivityDto.java
@@ -1,0 +1,14 @@
+package com.example.timebank.dto;
+
+import lombok.Data;
+import java.util.Set;
+
+@Data
+public class ActivityDto {
+    private Long id;
+    private String title;
+    private String description;
+    private int durationHours;
+    private Long instructorId;
+    private Set<Long> participantIds;
+}

--- a/src/main/java/com/example/timebank/dto/UserDto.java
+++ b/src/main/java/com/example/timebank/dto/UserDto.java
@@ -1,0 +1,14 @@
+package com.example.timebank.dto;
+
+import lombok.Data;
+
+@Data
+public class UserDto {
+    private Long id;
+    private String firstName;
+    private String lastName;
+    private String email;
+    private String phone;
+    private String password;
+    private double hoursCredit;
+}

--- a/src/main/java/com/example/timebank/mapper/ActivityMapper.java
+++ b/src/main/java/com/example/timebank/mapper/ActivityMapper.java
@@ -1,0 +1,32 @@
+package com.example.timebank.mapper;
+
+import com.example.timebank.domain.Activity;
+import com.example.timebank.dto.ActivityDto;
+import com.example.timebank.domain.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+@Mapper(componentModel = "spring")
+public interface ActivityMapper {
+    @Mapping(target = "instructorId", source = "instructor.id")
+    @Mapping(target = "participantIds", source = "participants", qualifiedByName = "userToId")
+    ActivityDto toDto(Activity activity);
+
+    @Mapping(target = "instructor.id", source = "instructorId")
+    @Mapping(target = "participants", source = "participantIds", qualifiedByName = "idToUser")
+    Activity toEntity(ActivityDto dto);
+
+    @Named("userToId")
+    static Long mapUserToId(User user) {
+        return user.getId();
+    }
+
+    @Named("idToUser")
+    static User mapIdToUser(Long id) {
+        if (id == null) return null;
+        User user = new User();
+        user.setId(id);
+        return user;
+    }
+}

--- a/src/main/java/com/example/timebank/mapper/UserMapper.java
+++ b/src/main/java/com/example/timebank/mapper/UserMapper.java
@@ -1,0 +1,11 @@
+package com.example.timebank.mapper;
+
+import com.example.timebank.domain.User;
+import com.example.timebank.dto.UserDto;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface UserMapper {
+    UserDto toDto(User user);
+    User toEntity(UserDto dto);
+}

--- a/src/main/java/com/example/timebank/repository/ActivityRepository.java
+++ b/src/main/java/com/example/timebank/repository/ActivityRepository.java
@@ -1,0 +1,7 @@
+package com.example.timebank.repository;
+
+import com.example.timebank.domain.Activity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActivityRepository extends JpaRepository<Activity, Long> {
+}

--- a/src/main/java/com/example/timebank/repository/UserRepository.java
+++ b/src/main/java/com/example/timebank/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.example.timebank.repository;
+
+import com.example.timebank.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/example/timebank/service/ActivityService.java
+++ b/src/main/java/com/example/timebank/service/ActivityService.java
@@ -1,0 +1,10 @@
+package com.example.timebank.service;
+
+import com.example.timebank.dto.ActivityDto;
+
+import java.util.List;
+
+public interface ActivityService {
+    ActivityDto create(ActivityDto dto);
+    List<ActivityDto> findAll();
+}

--- a/src/main/java/com/example/timebank/service/UserService.java
+++ b/src/main/java/com/example/timebank/service/UserService.java
@@ -1,0 +1,10 @@
+package com.example.timebank.service;
+
+import com.example.timebank.dto.UserDto;
+
+import java.util.List;
+
+public interface UserService {
+    UserDto create(UserDto user);
+    List<UserDto> findAll();
+}

--- a/src/main/java/com/example/timebank/service/impl/ActivityServiceImpl.java
+++ b/src/main/java/com/example/timebank/service/impl/ActivityServiceImpl.java
@@ -1,0 +1,30 @@
+package com.example.timebank.service.impl;
+
+import com.example.timebank.dto.ActivityDto;
+import com.example.timebank.mapper.ActivityMapper;
+import com.example.timebank.repository.ActivityRepository;
+import com.example.timebank.service.ActivityService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ActivityServiceImpl implements ActivityService {
+    private final ActivityRepository repository;
+    private final ActivityMapper mapper;
+
+    @Override
+    public ActivityDto create(ActivityDto dto) {
+        var entity = mapper.toEntity(dto);
+        var saved = repository.save(entity);
+        return mapper.toDto(saved);
+    }
+
+    @Override
+    public List<ActivityDto> findAll() {
+        return repository.findAll().stream().map(mapper::toDto).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/timebank/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/timebank/service/impl/UserServiceImpl.java
@@ -1,0 +1,33 @@
+package com.example.timebank.service.impl;
+
+import com.example.timebank.dto.UserDto;
+import com.example.timebank.mapper.UserMapper;
+import com.example.timebank.repository.UserRepository;
+import com.example.timebank.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+    private final UserRepository userRepository;
+    private final UserMapper mapper;
+
+    @Override
+    public UserDto create(UserDto userDto) {
+        var user = mapper.toEntity(userDto);
+        var saved = userRepository.save(user);
+        return mapper.toDto(saved);
+    }
+
+    @Override
+    public List<UserDto> findAll() {
+        return userRepository.findAll()
+                .stream()
+                .map(mapper::toDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/timebank
+    username: postgres
+    password: postgres
+  jpa:
+    hibernate:
+      ddl-auto: update


### PR DESCRIPTION
## Summary
- switch Spring configuration to `application.yml`
- expand `User` with authentication and contact fields
- allow activities to store enrolled users
- expose participants and new user fields in DTOs
- map participants in `ActivityMapper`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68441fc5629c832cb8a95415e52b34ba