### PR TITLE
Add Docker support and align entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,25 @@ Endpoints destacados de actividades:
 - `GET /activities/filter?...` combina todos los criterios anteriores.
 
 La configuración de Spring se encuentra en `boot/src/main/resources/application.yml`.
+
+## Base de datos
+
+El servicio utiliza PostgreSQL como base de datos. Los valores de conexión por defecto son:
+
+```
+url: jdbc:postgresql://localhost:5432/timebank
+usuario: postgres
+contraseña: postgres
+```
+
+Antes de arrancar la aplicación, asegúrate de que existe una instancia de PostgreSQL con esa base de datos creada. Para facilitarlo se incluye un `docker-compose.yml` que lanza un contenedor con dichas credenciales:
+
+```bash
+docker-compose up -d
+```
+
+Después puedes ejecutar la aplicación normalmente con:
+
+```bash
+mvn -pl boot spring-boot:run
+```

--- a/adapters/src/main/java/es/doterorgz/timebank/adapters/entities/ActivityEntity.java
+++ b/adapters/src/main/java/es/doterorgz/timebank/adapters/entities/ActivityEntity.java
@@ -1,4 +1,36 @@
 package es.doterorgz.timebank.adapters.entities;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+/**
+ * JPA entity used to persist Activity data.
+ */
+@Entity
+@Table(name = "activity")
+@Data
 public class ActivityEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String description;
+
+    private int durationHours;
+
+    private double latitude;
+
+    private double longitude;
+
+    @Column(name = "start_date_time")
+    private LocalDateTime startDateTime;
 }

--- a/adapters/src/main/java/es/doterorgz/timebank/adapters/entities/UserEntity.java
+++ b/adapters/src/main/java/es/doterorgz/timebank/adapters/entities/UserEntity.java
@@ -1,4 +1,33 @@
 package es.doterorgz.timebank.adapters.entities;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+/**
+ * JPA entity used to persist User data.
+ */
+@Entity
+@Table(name = "users")
+@Data
 public class UserEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String firstName;
+
+    private String lastName;
+
+    private String email;
+
+    private String phone;
+
+    private String password;
+
+    private double hoursCredit;
 }

--- a/adapters/src/main/java/es/doterorgz/timebank/repository/ActivityRepository.java
+++ b/adapters/src/main/java/es/doterorgz/timebank/repository/ActivityRepository.java
@@ -17,7 +17,7 @@ public interface ActivityRepository extends JpaRepository<ActivityEntity, Long> 
             "(concat('%', :text, '%'))")
     List<Activity> searchByText(@Param("text") String text);
 
-    @Query("SELECT a FROM Activityentity a WHERE a.startDateTime BETWEEN :start AND :end")
+    @Query("SELECT a FROM ActivityEntity a WHERE a.startDateTime BETWEEN :start AND :end")
     List<Activity> findByDateRange(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
     @Query(value = "SELECT * FROM activity a WHERE earth_distance(ll_to_earth(:lat, :lon), ll_to_earth(a.latitude, a.longitude)) <= :distance AND (lower(a.title) LIKE lower(concat('%', :text, '%')) OR lower(a.description) LIKE lower(concat('%', :text, '%'))) AND a.start_date_time BETWEEN :start AND :end", nativeQuery = true)

--- a/adapters/src/main/java/es/doterorgz/timebank/service/impl/ActivityServiceImpl.java
+++ b/adapters/src/main/java/es/doterorgz/timebank/service/impl/ActivityServiceImpl.java
@@ -15,7 +15,7 @@ public class ActivityServiceImpl implements ActivityService {
     private final ActivityRepository repository;
 
     @Override
-    public Activity save(Activity activity) {
+    public Activity create(Activity activity) {
         return repository.save(activity);
     }
 

--- a/adapters/src/test/java/es/doterorgz/timebank/service/impl/ActivityServiceImplTest.java
+++ b/adapters/src/test/java/es/doterorgz/timebank/service/impl/ActivityServiceImplTest.java
@@ -1,0 +1,34 @@
+package es.doterorgz.timebank.service.impl;
+
+import es.doterorgz.timebank.domain.Activity;
+import es.doterorgz.timebank.repository.ActivityRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+@ExtendWith(MockitoExtension.class)
+class ActivityServiceImplTest {
+
+    @Mock
+    private ActivityRepository repository;
+
+    @InjectMocks
+    private ActivityServiceImpl service;
+
+    @Test
+    void createDelegatesToRepository() {
+        Activity activity = new Activity();
+        when(repository.save(activity)).thenReturn(activity);
+
+        Activity result = service.create(activity);
+
+        verify(repository).save(activity);
+        assertSame(activity, result);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: timebank
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - db-data:/var/lib/postgresql/data
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- document PostgreSQL details and docker-compose usage in README
- implement ActivityEntity and UserEntity with all DB fields
- fix query typo in ActivityRepository
- rename `save` method to `create` in ActivityServiceImpl
- provide a unit test for ActivityServiceImpl
- add docker-compose file for PostgreSQL

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447297c0a8832ca1ddd620b09ad55b