### PR TITLE
Implement CRUD operations for users and activities

### DIFF
--- a/adapters/src/main/java/es/doterorgz/timebank/service/impl/ActivityServiceImpl.java
+++ b/adapters/src/main/java/es/doterorgz/timebank/service/impl/ActivityServiceImpl.java
@@ -30,6 +30,24 @@ public class ActivityServiceImpl implements ActivityService {
     }
 
     @Override
+    public Activity findById(Long id) {
+        return repository.findById(id).map(mapper::toDomain).orElse(null);
+    }
+
+    @Override
+    public Activity update(Long id, Activity activity) {
+        ActivityEntity entity = mapper.toEntity(activity);
+        entity.setId(id);
+        ActivityEntity saved = repository.save(entity);
+        return mapper.toDomain(saved);
+    }
+
+    @Override
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+
+    @Override
     public List<Activity> findByLocation(double latitude, double longitude, double distance) {
         return repository.findByLocation(latitude, longitude, distance).stream()
                 .map(mapper::toDomain)

--- a/adapters/src/main/java/es/doterorgz/timebank/service/impl/UserServiceImpl.java
+++ b/adapters/src/main/java/es/doterorgz/timebank/service/impl/UserServiceImpl.java
@@ -27,4 +27,22 @@ public class UserServiceImpl implements UserService {
     public List<User> findAll() {
         return userRepository.findAll().stream().map(mapper::toDomain).toList();
     }
+
+    @Override
+    public User findById(Long id) {
+        return userRepository.findById(id).map(mapper::toDomain).orElse(null);
+    }
+
+    @Override
+    public User update(Long id, User user) {
+        UserEntity entity = mapper.toEntity(user);
+        entity.setId(id);
+        UserEntity saved = userRepository.save(entity);
+        return mapper.toDomain(saved);
+    }
+
+    @Override
+    public void delete(Long id) {
+        userRepository.deleteById(id);
+    }
 }

--- a/api-rest/src/main/java/es/doterorgz/timebank/adapter/rest/ActivityController.java
+++ b/api-rest/src/main/java/es/doterorgz/timebank/adapter/rest/ActivityController.java
@@ -8,6 +8,9 @@ import es.doterorgz.timebank.usecase.FindActivitiesByLocationUseCase;
 import es.doterorgz.timebank.usecase.FindAllActivitiesUseCase;
 import es.doterorgz.timebank.usecase.SearchActivitiesByTextUseCase;
 import es.doterorgz.timebank.usecase.SearchActivitiesUseCase;
+import es.doterorgz.timebank.usecase.FindActivityByIdUseCase;
+import es.doterorgz.timebank.usecase.UpdateActivityUseCase;
+import es.doterorgz.timebank.usecase.DeleteActivityUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +28,9 @@ public class ActivityController {
     private final SearchActivitiesByTextUseCase searchActivitiesByTextUseCase;
     private final FindActivitiesByDateRangeUseCase findActivitiesByDateRangeUseCase;
     private final SearchActivitiesUseCase searchActivitiesUseCase;
+    private final FindActivityByIdUseCase findActivityByIdUseCase;
+    private final UpdateActivityUseCase updateActivityUseCase;
+    private final DeleteActivityUseCase deleteActivityUseCase;
     private final ActivityMapper mapper;
 
     @PostMapping
@@ -37,6 +43,15 @@ public class ActivityController {
     @GetMapping
     public ResponseEntity<List<ActivityDto>> findAll() {
         return ResponseEntity.ok(findAllActivitiesUseCase.execute().stream().map(mapper::toDto).toList());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ActivityDto> findById(@PathVariable Long id) {
+        var activity = findActivityByIdUseCase.execute(id);
+        if (activity == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(mapper.toDto(activity));
     }
 
     @GetMapping("/location")
@@ -67,5 +82,18 @@ public class ActivityController {
                                                     @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) java.time.LocalDateTime end) {
         return ResponseEntity.ok(searchActivitiesUseCase.execute(lat, lon, distance, text, start, end)
                 .stream().map(mapper::toDto).toList());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ActivityDto> update(@PathVariable Long id, @RequestBody ActivityDto dto) {
+        var activity = mapper.toEntity(dto);
+        var updated = updateActivityUseCase.execute(id, activity);
+        return ResponseEntity.ok(mapper.toDto(updated));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        deleteActivityUseCase.execute(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/api-rest/src/main/java/es/doterorgz/timebank/adapter/rest/UserController.java
+++ b/api-rest/src/main/java/es/doterorgz/timebank/adapter/rest/UserController.java
@@ -4,6 +4,9 @@ import es.doterorgz.timebank.dto.UserDto;
 import es.doterorgz.timebank.mapper.UserMapper;
 import es.doterorgz.timebank.usecase.CreateUserUseCase;
 import es.doterorgz.timebank.usecase.FindAllUsersUseCase;
+import es.doterorgz.timebank.usecase.FindUserByIdUseCase;
+import es.doterorgz.timebank.usecase.UpdateUserUseCase;
+import es.doterorgz.timebank.usecase.DeleteUserUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,6 +19,9 @@ import java.util.List;
 public class UserController {
     private final CreateUserUseCase createUserUseCase;
     private final FindAllUsersUseCase findAllUsersUseCase;
+    private final FindUserByIdUseCase findUserByIdUseCase;
+    private final UpdateUserUseCase updateUserUseCase;
+    private final DeleteUserUseCase deleteUserUseCase;
     private final UserMapper mapper;
 
     @PostMapping
@@ -28,5 +34,27 @@ public class UserController {
     @GetMapping
     public ResponseEntity<List<UserDto>> findAll() {
         return ResponseEntity.ok(findAllUsersUseCase.execute().stream().map(mapper::toDto).toList());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<UserDto> findById(@PathVariable Long id) {
+        var user = findUserByIdUseCase.execute(id);
+        if (user == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(mapper.toDto(user));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<UserDto> update(@PathVariable Long id, @RequestBody UserDto dto) {
+        var user = mapper.toEntity(dto);
+        var updated = updateUserUseCase.execute(id, user);
+        return ResponseEntity.ok(mapper.toDto(updated));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        deleteUserUseCase.execute(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/application/src/main/java/es/doterorgz/timebank/usecase/impl/DeleteActivityUseCaseImpl.java
+++ b/application/src/main/java/es/doterorgz/timebank/usecase/impl/DeleteActivityUseCaseImpl.java
@@ -1,0 +1,18 @@
+package es.doterorgz.timebank.usecase.impl;
+
+import es.doterorgz.timebank.service.ActivityService;
+import es.doterorgz.timebank.usecase.DeleteActivityUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteActivityUseCaseImpl implements DeleteActivityUseCase {
+
+    private final ActivityService activityService;
+
+    @Override
+    public void execute(Long id) {
+        activityService.delete(id);
+    }
+}

--- a/application/src/main/java/es/doterorgz/timebank/usecase/impl/DeleteUserUseCaseImpl.java
+++ b/application/src/main/java/es/doterorgz/timebank/usecase/impl/DeleteUserUseCaseImpl.java
@@ -1,0 +1,18 @@
+package es.doterorgz.timebank.usecase.impl;
+
+import es.doterorgz.timebank.service.UserService;
+import es.doterorgz.timebank.usecase.DeleteUserUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteUserUseCaseImpl implements DeleteUserUseCase {
+
+    private final UserService userService;
+
+    @Override
+    public void execute(Long id) {
+        userService.delete(id);
+    }
+}

--- a/application/src/main/java/es/doterorgz/timebank/usecase/impl/FindActivityByIdUseCaseImpl.java
+++ b/application/src/main/java/es/doterorgz/timebank/usecase/impl/FindActivityByIdUseCaseImpl.java
@@ -1,0 +1,19 @@
+package es.doterorgz.timebank.usecase.impl;
+
+import es.doterorgz.timebank.domain.Activity;
+import es.doterorgz.timebank.service.ActivityService;
+import es.doterorgz.timebank.usecase.FindActivityByIdUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FindActivityByIdUseCaseImpl implements FindActivityByIdUseCase {
+
+    private final ActivityService activityService;
+
+    @Override
+    public Activity execute(Long id) {
+        return activityService.findById(id);
+    }
+}

--- a/application/src/main/java/es/doterorgz/timebank/usecase/impl/FindUserByIdUseCaseImpl.java
+++ b/application/src/main/java/es/doterorgz/timebank/usecase/impl/FindUserByIdUseCaseImpl.java
@@ -1,0 +1,19 @@
+package es.doterorgz.timebank.usecase.impl;
+
+import es.doterorgz.timebank.domain.User;
+import es.doterorgz.timebank.service.UserService;
+import es.doterorgz.timebank.usecase.FindUserByIdUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FindUserByIdUseCaseImpl implements FindUserByIdUseCase {
+
+    private final UserService userService;
+
+    @Override
+    public User execute(Long id) {
+        return userService.findById(id);
+    }
+}

--- a/application/src/main/java/es/doterorgz/timebank/usecase/impl/UpdateActivityUseCaseImpl.java
+++ b/application/src/main/java/es/doterorgz/timebank/usecase/impl/UpdateActivityUseCaseImpl.java
@@ -1,0 +1,19 @@
+package es.doterorgz.timebank.usecase.impl;
+
+import es.doterorgz.timebank.domain.Activity;
+import es.doterorgz.timebank.service.ActivityService;
+import es.doterorgz.timebank.usecase.UpdateActivityUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateActivityUseCaseImpl implements UpdateActivityUseCase {
+
+    private final ActivityService activityService;
+
+    @Override
+    public Activity execute(Long id, Activity activity) {
+        return activityService.update(id, activity);
+    }
+}

--- a/application/src/main/java/es/doterorgz/timebank/usecase/impl/UpdateUserUseCaseImpl.java
+++ b/application/src/main/java/es/doterorgz/timebank/usecase/impl/UpdateUserUseCaseImpl.java
@@ -1,0 +1,19 @@
+package es.doterorgz.timebank.usecase.impl;
+
+import es.doterorgz.timebank.domain.User;
+import es.doterorgz.timebank.service.UserService;
+import es.doterorgz.timebank.usecase.UpdateUserUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateUserUseCaseImpl implements UpdateUserUseCase {
+
+    private final UserService userService;
+
+    @Override
+    public User execute(Long id, User user) {
+        return userService.update(id, user);
+    }
+}

--- a/domain/src/main/java/es/doterorgz/timebank/service/ActivityService.java
+++ b/domain/src/main/java/es/doterorgz/timebank/service/ActivityService.java
@@ -10,6 +10,12 @@ public interface ActivityService {
 
     List<Activity> findAll();
 
+    Activity findById(Long id);
+
+    Activity update(Long id, Activity activity);
+
+    void delete(Long id);
+
     List<Activity> findByLocation(double latitude, double longitude, double distance);
 
     List<Activity> searchByText(String text);

--- a/domain/src/main/java/es/doterorgz/timebank/service/UserService.java
+++ b/domain/src/main/java/es/doterorgz/timebank/service/UserService.java
@@ -8,4 +8,10 @@ public interface UserService {
     User create(User user);
 
     List<User> findAll();
+
+    User findById(Long id);
+
+    User update(Long id, User user);
+
+    void delete(Long id);
 }

--- a/domain/src/main/java/es/doterorgz/timebank/usecase/DeleteActivityUseCase.java
+++ b/domain/src/main/java/es/doterorgz/timebank/usecase/DeleteActivityUseCase.java
@@ -1,0 +1,5 @@
+package es.doterorgz.timebank.usecase;
+
+public interface DeleteActivityUseCase {
+    void execute(Long id);
+}

--- a/domain/src/main/java/es/doterorgz/timebank/usecase/DeleteUserUseCase.java
+++ b/domain/src/main/java/es/doterorgz/timebank/usecase/DeleteUserUseCase.java
@@ -1,0 +1,5 @@
+package es.doterorgz.timebank.usecase;
+
+public interface DeleteUserUseCase {
+    void execute(Long id);
+}

--- a/domain/src/main/java/es/doterorgz/timebank/usecase/FindActivityByIdUseCase.java
+++ b/domain/src/main/java/es/doterorgz/timebank/usecase/FindActivityByIdUseCase.java
@@ -1,0 +1,7 @@
+package es.doterorgz.timebank.usecase;
+
+import es.doterorgz.timebank.domain.Activity;
+
+public interface FindActivityByIdUseCase {
+    Activity execute(Long id);
+}

--- a/domain/src/main/java/es/doterorgz/timebank/usecase/FindUserByIdUseCase.java
+++ b/domain/src/main/java/es/doterorgz/timebank/usecase/FindUserByIdUseCase.java
@@ -1,0 +1,7 @@
+package es.doterorgz.timebank.usecase;
+
+import es.doterorgz.timebank.domain.User;
+
+public interface FindUserByIdUseCase {
+    User execute(Long id);
+}

--- a/domain/src/main/java/es/doterorgz/timebank/usecase/UpdateActivityUseCase.java
+++ b/domain/src/main/java/es/doterorgz/timebank/usecase/UpdateActivityUseCase.java
@@ -1,0 +1,7 @@
+package es.doterorgz.timebank.usecase;
+
+import es.doterorgz.timebank.domain.Activity;
+
+public interface UpdateActivityUseCase {
+    Activity execute(Long id, Activity activity);
+}

--- a/domain/src/main/java/es/doterorgz/timebank/usecase/UpdateUserUseCase.java
+++ b/domain/src/main/java/es/doterorgz/timebank/usecase/UpdateUserUseCase.java
@@ -1,0 +1,7 @@
+package es.doterorgz.timebank.usecase;
+
+import es.doterorgz.timebank.domain.User;
+
+public interface UpdateUserUseCase {
+    User execute(Long id, User user);
+}


### PR DESCRIPTION
## Summary
- add CRUD service interfaces for Activity and User
- implement find, update and delete in service implementations
- expose CRUD endpoints in ActivityController and UserController
- add use case interfaces and implementations for new operations

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684571826198832ca59e6579da0c042b