### PR TITLE
Add Docker build and deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: docker.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ${{ secrets.REGISTRY_USER }}/timebank:latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Build JAR
+        run: mvn -B -pl boot package
+      - name: Build Docker image
+        run: |
+          docker build -t $IMAGE_NAME .
+      - name: Log in to registry
+        run: echo "${{ secrets.REGISTRY_TOKEN }}" | docker login -u "${{ secrets.REGISTRY_USER }}" --password-stdin $REGISTRY
+      - name: Push image
+        run: docker push $IMAGE_NAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:21-jdk-slim
+
+# Copy the Spring Boot fat jar built in the boot module
+COPY boot/target/*.jar /app.jar
+
+ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
## Summary
- containerize the boot jar with a Dockerfile
- add GitHub Actions workflow to build the jar, build the image and push it to a registry

## Testing
- `mvn -q -pl boot test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845b75e921c832ca6e77c16677f3d3f